### PR TITLE
Update Jackson to 2.9.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <curator-version>4.2.0</curator-version>
-        <jackson-version>2.9.9</jackson-version>
+        <jackson-version>2.9.10</jackson-version>
         <testng-version>6.10</testng-version>
         <slf4j-version>1.7.22</slf4j-version>
         <jgrapht-version>1.0.1</jgrapht-version>


### PR DESCRIPTION
CVE-2019-16335 More information
critical severity
Vulnerable versions: < 2.9.10
Patched version: 2.9.10
A Polymorphic Typing issue was discovered in FasterXML jackson-databind before 2.9.10. It is related to com.zaxxer.hikari.HikariDataSource. This is a different vulnerability than CVE-2019-14540.

CVE-2019-14540 More information
critical severity
Vulnerable versions: < 2.9.10
Patched version: 2.9.10
A Polymorphic Typing issue was discovered in FasterXML jackson-databind before 2.9.10. It is related to com.zaxxer.hikari.HikariConfig.