### PR TITLE
Avoid continuous setting of watchers by using a Persistent watch.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <curator-version>4.2.0</curator-version>
+        <curator-version>5.1.0</curator-version>
         <jackson-version>2.12.1</jackson-version>
         <testng-version>6.10</testng-version>
         <slf4j-version>1.7.22</slf4j-version>


### PR DESCRIPTION
Avoid continuous setting of watchers by using a Persistent watch. This should fix the reported memory issue with many watchers being set.

Note: this requires ZooKeeper 3.6.x or above

Fixes #44